### PR TITLE
Bug on the cache logic

### DIFF
--- a/wp-sass.php
+++ b/wp-sass.php
@@ -123,6 +123,8 @@ class wp_sass {
 				} else {
 					$full_cache[ 'css' ] = $this->__parse( $sass_path, $syntax );
 				}
+				// update cache creation time
+				$full_cache[ 'updated' ] = filemtime( $sass_path );
 				file_put_contents( $cache_path, serialize( $full_cache ) );
 				file_put_contents( $css_path, $full_cache[ 'css' ] );
 			}


### PR DESCRIPTION
The plugin was rebuilding the cache on every request because it wasn't storing
the last updated time on the cache metadata.

We are using this on a new site and it's working fine but we detected that it was using a lot of cpu and after profiling we saw that there was this small bug causing it.

Hope this helps to many others!

Regards,
Sebastian Decima
